### PR TITLE
Update DMN procrastination regexes and add tests

### DIFF
--- a/dmn_security_lab.py
+++ b/dmn_security_lab.py
@@ -1,0 +1,25 @@
+import re
+from dataclasses import dataclass
+from typing import List
+
+PROCRAST_PHRASES: List[str] = [
+    r"procrastinat(?:ing|e|ion)",
+    r"tomorrow",
+    r"later",
+    r"idk",
+    r"not now",
+]
+
+
+@dataclass
+class DMNCheckResult:
+    matched: bool
+    pattern: str | None = None
+
+
+def check_for_procrastination(text: str) -> DMNCheckResult:
+    """Return whether the supplied text triggers the procrastination policy."""
+    for pattern in PROCRAST_PHRASES:
+        if re.search(pattern, text, flags=re.IGNORECASE):
+            return DMNCheckResult(True, pattern)
+    return DMNCheckResult(False, None)

--- a/tests/test_dmn_security_lab.py
+++ b/tests/test_dmn_security_lab.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from dmn_security_lab import PROCRAST_PHRASES, check_for_procrastination
+
+
+def test_tomorrow_triggers_policy():
+    result = check_for_procrastination("Tomorrow I'll do it")
+    assert result.matched
+    assert any(pattern == result.pattern for pattern in PROCRAST_PHRASES)
+
+
+def test_not_now_triggers_policy():
+    result = check_for_procrastination("Not now, maybe later")
+    assert result.matched
+    assert any(pattern == result.pattern for pattern in PROCRAST_PHRASES)
+
+
+def test_regexes_have_no_leading_space():
+    assert all(not pattern.startswith(" ") for pattern in PROCRAST_PHRASES)


### PR DESCRIPTION
## Summary
- add a DMN security lab helper that lists procrastination phrases without leading spaces
- provide a utility to check inputs against the procrastination policy
- cover tomorrow/not now phrases with tests to confirm the regexes trigger the DMN logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc047ad01c83238f392e3b93b73182