### PR TITLE
Fix procrastination phrase detection at string boundaries

### DIFF
--- a/dmn_security_lab.py
+++ b/dmn_security_lab.py
@@ -1,0 +1,85 @@
+"""Utilities for scoring procrastination-related phrases.
+
+This module provides a simple helper that looks for any occurrence of
+pre-defined procrastination phrases in an input string.  The list of
+phrases is shared with a DMN (Decision Management Network) policy that
+assigns additional scoring when procrastination intent is detected.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable, List
+
+# Patterns that should trigger additional scoring for procrastination intent.
+#
+# Historically these strings contained leading spaces (e.g. ``" tomorrow"``)
+# to avoid matching other words.  That approach broke detection for inputs
+# that started with the phrase or were preceded by punctuation, so the
+# patterns are now written without those literal spaces.
+PROCRAST_PHRASES: List[str] = [
+    r"procrastinat(ing|e|ion)",
+    r"tomorrow",
+    r"later",
+    r"idk",
+    r"not now",
+]
+
+
+@dataclass
+class ProcrastinationMatch:
+    """Represents the result of scanning text for procrastination signals."""
+
+    phrase: str
+    pattern: str
+    span: tuple[int, int]
+
+
+def find_procrastination_phrases(
+    text: str, patterns: Iterable[str] | None = None
+) -> List[ProcrastinationMatch]:
+    """Return matches for procrastination phrases in ``text``.
+
+    Parameters
+    ----------
+    text:
+        The text that should be scanned for procrastination intent.
+    patterns:
+        Optional custom iterable of regex patterns.  When omitted the global
+        :data:`PROCRAST_PHRASES` list is used.
+    """
+
+    compiled_patterns = [
+        re.compile(pattern, flags=re.IGNORECASE) for pattern in patterns or PROCRAST_PHRASES
+    ]
+
+    matches: List[ProcrastinationMatch] = []
+    for pattern, compiled in zip(patterns or PROCRAST_PHRASES, compiled_patterns):
+        for match in compiled.finditer(text):
+            matches.append(
+                ProcrastinationMatch(
+                    phrase=text[match.start() : match.end()],
+                    pattern=pattern,
+                    span=match.span(),
+                )
+            )
+    return matches
+
+
+def score_procrastination(text: str) -> int:
+    """Return a simple score equal to the number of procrastination matches.
+
+    The DMN policy consumes this score to determine whether to escalate or
+    route the request differently.  This helper mimics the production logic so
+    the matching behaviour can be verified in tests.
+    """
+
+    return len(find_procrastination_phrases(text))
+
+
+__all__ = [
+    "PROCRAST_PHRASES",
+    "ProcrastinationMatch",
+    "find_procrastination_phrases",
+    "score_procrastination",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_procrastination_detection.py
+++ b/tests/test_procrastination_detection.py
@@ -1,0 +1,36 @@
+import pytest
+
+from dmn_security_lab import PROCRAST_PHRASES, find_procrastination_phrases, score_procrastination
+
+
+def _matches(text: str):
+    return [match.phrase for match in find_procrastination_phrases(text)]
+
+
+def test_tomorrow_phrase_matches_without_leading_space():
+    text = "Tomorrow I'll do it"
+    matches = _matches(text)
+
+    assert score_procrastination(text) > 0
+    assert any(match.lower().startswith("tomorrow") for match in matches)
+
+
+def test_not_now_detected_at_start_of_string():
+    text = "Not now"
+    matches = _matches(text)
+
+    assert score_procrastination(text) > 0
+    assert any(match.lower().startswith("not now") for match in matches)
+
+
+def test_patterns_have_no_leading_spaces():
+    offending = [pattern for pattern in PROCRAST_PHRASES if pattern.startswith(" ")]
+    assert offending == []
+
+
+def test_punctuation_preceding_idk_is_detected():
+    text = "Fine... idk"
+    matches = _matches(text)
+
+    assert score_procrastination(text) > 0
+    assert any("idk" in match.lower() for match in matches)


### PR DESCRIPTION
## Summary
- add a DMN helper module exposing procrastination phrase patterns without leading spaces
- provide simple scoring utilities to mirror the policy expectations and enable testing
- add tests confirming phrases like "Tomorrow I'll do it" and "Not now" trigger the detection logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3eb8a9cd08323878830e3b4f7c243